### PR TITLE
AppConfig.name is used instead of AppConfig.label for importing packages

### DIFF
--- a/django_ddd/apps_config/clean_app_config.py
+++ b/django_ddd/apps_config/clean_app_config.py
@@ -16,7 +16,7 @@ class CleanAppConfig(AppConfig):
         self.__load_custom_models_module()
 
     def __load_custom_models_module(self) -> None:
-        self.models_module = import_module(f"{self.label}.{self.CUSTOM_MODELS_MODULE}")
+        self.models_module = import_module(f"{self.name}.{self.CUSTOM_MODELS_MODULE}")
 
     def ready(self) -> None:
         self.__load_custom_admin_module(self.CUSTOM_ADMIN_MODULE, register_to=site)
@@ -26,4 +26,4 @@ class CleanAppConfig(AppConfig):
         autodiscover_modules(admin_module, register_to=register_to)
 
     def __load_custom_migration_module(self, migration_module: str) -> None:
-        settings.MIGRATION_MODULES.update(**{self.label: f"{self.label}.{migration_module}"})
+        settings.MIGRATION_MODULES.update(**{self.label: f"{self.name}.{migration_module}"})


### PR DESCRIPTION
As it is stated in Django documentation AppConfig.name is responsible for storing the full Python path to django app: https://docs.djangoproject.com/en/3.2/ref/applications/#django.apps.AppConfig.name

I have this project structure:
```
core/__init__.py
       settings.py
       ...
apps/__init__.py
        myapp/__init__.py
                   infrastructure/__init__.py
                                        apps.py
```

So when running the old implementation Django would try to import "myapp.infrastructure.apps.MyappConfig" instead of "apps.myapp.infrastructure.apps.MyappConfig"