### PR TITLE
Edited process of creating path to modules in app config

### DIFF
--- a/django_ddd/apps_config/clean_app_config.py
+++ b/django_ddd/apps_config/clean_app_config.py
@@ -16,7 +16,7 @@ class CleanAppConfig(AppConfig):
         self.__load_custom_models_module()
 
     def __load_custom_models_module(self) -> None:
-        self.models_module = import_module(f"{self.label}.{self.CUSTOM_MODELS_MODULE}")
+        self.models_module = import_module(f"{self.name}.{self.CUSTOM_MODELS_MODULE}")
 
     def ready(self) -> None:
         self.__load_custom_admin_module(self.CUSTOM_ADMIN_MODULE, register_to=site)
@@ -26,4 +26,4 @@ class CleanAppConfig(AppConfig):
         autodiscover_modules(admin_module, register_to=register_to)
 
     def __load_custom_migration_module(self, migration_module: str) -> None:
-        settings.MIGRATION_MODULES.update(**{self.label: f"{self.label}.{migration_module}"})
+        settings.MIGRATION_MODULES.update(**{self.name: f"{self.name}.{migration_module}"})

--- a/django_ddd/apps_config/clean_app_config.py
+++ b/django_ddd/apps_config/clean_app_config.py
@@ -26,4 +26,4 @@ class CleanAppConfig(AppConfig):
         autodiscover_modules(admin_module, register_to=register_to)
 
     def __load_custom_migration_module(self, migration_module: str) -> None:
-        settings.MIGRATION_MODULES.update(**{self.name: f"{self.name}.{migration_module}"})
+        settings.MIGRATION_MODULES.update(**{self.label: f"{self.name}.{migration_module}"})


### PR DESCRIPTION
Hello!
I like DDD and Django. I appreciate your contribution to the development of these areas. But using your project, I discovered a problem in the formation of paths to django models and migrations. This problem prevents me from using bounded contexts because your project does not support nested directories of the application.

For example:
```
bound_context/
    app_folder/
        application/
        domain/
        infrastructure/
            migrations/
            admin.py
            models.py
            __init__.py
        __init__.py
```